### PR TITLE
`license=license` causes a runtime error.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ def main():
           install_requires=['sqlalchemy'],
           zip_safe=False,
           include_package_data=True,
-          license=license,
+          license='',
           package_dir={'': 'python'},
           packages=['opdb'],
           )


### PR DESCRIPTION
`license` in `setup.py` is a not a string (but a Python function), so `pip install ./spt_operational_database` causes an error.
We have to provide some suitable license text as https://github.com/Subaru-PFS/pfs_utils/blob/6abaf8adfd5866752bd3ba569ceb69a0909c001c/setup.py#L13 does.

The error I got was:
```
$ ./.venv/bin/pip install -e .
Obtaining file:///Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database
    ERROR: Command errored out with exit status 1:
     command: /Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/.venv/bin/python -c 'import io, os, sys, setuptools, tokenize; sys.argv[0] = '"'"'/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/setup.py'"'"'; __file__='"'"'/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/setup.py'"'"';f = getattr(tokenize, '"'"'open'"'"', open)(__file__) if os.path.exists(__file__) else io.StringIO('"'"'from setuptools import setup; setup()'"'"');code = f.read().replace('"'"'\r\n'"'"', '"'"'\n'"'"');f.close();exec(compile(code, __file__, '"'"'exec'"'"'))' egg_info --egg-base /private/var/folders/9r/2744fwv103l6s4t1lblm1mq00000gn/T/pip-pip-egg-info-c7605m8e
         cwd: /Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/
    Complete output (28 lines):
    running egg_info
    creating /private/var/folders/9r/2744fwv103l6s4t1lblm1mq00000gn/T/pip-pip-egg-info-c7605m8e/opdb.egg-info
    writing /private/var/folders/9r/2744fwv103l6s4t1lblm1mq00000gn/T/pip-pip-egg-info-c7605m8e/opdb.egg-info/PKG-INFO
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/setup.py", line 27, in <module>
        main()
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/setup.py", line 13, in main
        setup(name='opdb',
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/.venv/lib/python3.8/site-packages/setuptools/__init__.py", line 153, in setup
        return distutils.core.setup(**attrs)
      File "/Users/michitaro/opt/anaconda3/lib/python3.8/distutils/core.py", line 148, in setup
        dist.run_commands()
      File "/Users/michitaro/opt/anaconda3/lib/python3.8/distutils/dist.py", line 966, in run_commands
        self.run_command(cmd)
      File "/Users/michitaro/opt/anaconda3/lib/python3.8/distutils/dist.py", line 985, in run_command
        cmd_obj.run()
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/.venv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 292, in run
        writer(self, ep.name, os.path.join(self.egg_info, ep.name))
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/.venv/lib/python3.8/site-packages/setuptools/command/egg_info.py", line 635, in write_pkg_info
        metadata.write_pkg_info(cmd.egg_info)
      File "/Users/michitaro/opt/anaconda3/lib/python3.8/distutils/dist.py", line 1117, in write_pkg_info
        self.write_pkg_file(pkg_info)
      File "/Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database/.venv/lib/python3.8/site-packages/setuptools/dist.py", line 185, in write_pkg_file
        license = rfc822_escape(self.get_license())
      File "/Users/michitaro/opt/anaconda3/lib/python3.8/distutils/util.py", line 475, in rfc822_escape
        lines = header.split('\n')
    AttributeError: '_Printer' object has no attribute 'split'
    ----------------------------------------
WARNING: Discarding file:///Users/michitaro/Desktop/codes/pfs_obslog/spt_operational_database. Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
ERROR: Command errored out with exit status 1: python setup.py egg_info Check the logs for full command output.
```