### PR TITLE
Add tests for consistency of relations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@ alembic/opdb_summit/db.cfg
 alembic/opdb_summit/alembic/__pycache__/
 alembic/opdb_asrd/db.cfg
 alembic/opdb_asrd/alembic/__pycache__/
+/.venv

--- a/README.md
+++ b/README.md
@@ -84,3 +84,13 @@ $ alembic upgrade head
 
 * make announcement / change SpS AIT log status / and close JIRA ticket
 
+## Tests
+
+To test the consistency of relations of models, run the following commands.
+
+```
+python -m venv .venv
+./.venv/bin/pip install --editable .
+./.venv/bin/pip install --editable '.[dev]'
+./.venv/bin/pytest
+```

--- a/pytest.init
+++ b/pytest.init
@@ -1,0 +1,2 @@
+[pytest]
+addopts = --ignore alembic

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,12 @@ def main():
           license='',
           package_dir={'': 'python'},
           packages=['opdb'],
+          extras_require={
+              'dev': [
+                  'pytest',
+                  'alembic',
+              ],
+          },
           )
 
 if __name__ == '__main__':

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -1,0 +1,10 @@
+from opdb import models
+from sqlalchemy.orm import aliased
+
+
+def test_relations_consistency():
+    # get the first model
+    model = next(iter(models.Base.registry.mappers))
+
+    # aliased involves some consistency checks
+    aliased(model)


### PR DESCRIPTION
The current master branch contains some inconsistencies in relations between models.

This is one of the inconsistencies.
```
sqlalchemy.exc.ArgumentError: Error creating backref 'psf_design_fiber' on relationship 'pfs_design_agc.pfs_designs': property of that name exists on mapper 'mapped class pfs_design->pfs_design'
```

This PR adds scripts to test the relation-consistency and instructions to run the test.

(This PR does not include the fixes of the inconsistencies itself.)