### PR TITLE
FITS header search

### DIFF
--- a/python/opdb/obslog/__init__.py
+++ b/python/opdb/obslog/__init__.py
@@ -1,0 +1,44 @@
+import re
+from os import PathLike
+from pathlib import Path
+from typing import Any, Dict, List
+
+import astropy.io.fits as pyfits
+from astropy.io.fits.hdu.hdulist import HDUList
+from sqlalchemy.orm import Session
+
+from .. import models
+
+
+def add_fits_headers_from_file(db: Session, filepath: PathLike):
+    db.add_all(fits_headers_from_file(filepath, pfs_visit_id=guess_pfs_visit_id(filepath)))
+
+
+def fits_headers_from_file(filepath: PathLike, pfs_visit_id: int):
+    with pyfits.open(filepath) as hdul:
+        return fits_headers_from_hdulist(hdul, pfs_visit_id, Path(filepath).stem)
+
+
+def fits_headers_from_hdulist(hdul: HDUList, pfs_visit_id: int, filestem: str):
+    records: List[models.obslog_fits_header] = []
+    for hdu_index, hdu in enumerate(hdul):
+        cards: Dict[str, Any] = {}
+        for name, value, _ in hdu.header.cards:
+            cards.setdefault(name, []).append(value)
+        record = models.obslog_fits_header(
+            pfs_visit_id=pfs_visit_id,
+            filestem=filestem,
+            hdu_index=hdu_index,
+            cards_dict={name: value[0] for name, value in cards.items() if len(value) == 1},
+            cards_list=[list(card) for card in hdu.header.cards],
+        )
+        records.append(record)
+    return records
+
+
+def guess_pfs_visit_id(filepath: PathLike):
+    filestem = Path(filepath).stem  # PFSA01967811 or PFSC06879100.fits
+    m = re.match(r'PFS[A-D](\d{6})\d{2}$', filestem)
+    if m is None:
+        raise RuntimeError(f'Unexpected filename format: {filepath}')
+    return int(m.group(1))

--- a/python/opdb/obslog/__main__.py
+++ b/python/opdb/obslog/__main__.py
@@ -1,0 +1,67 @@
+import logging
+from pathlib import Path
+from typing import List
+
+import sqlalchemy
+from astropy.io.fits.util import ignore_sigint
+from opdb import models
+from opdb.obslog import add_fits_headers_from_file
+from sqlalchemy.engine.base import Engine
+from sqlalchemy.orm.session import Session
+
+logger = logging.getLogger(__name__)
+
+
+def main():
+    import argparse
+
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import sessionmaker
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--db-url', '-d', required=True)
+    parser.add_argument('--no-echo', dest='echo', default=True, action='store_false')
+    parser.set_defaults(action=lambda: parser.print_help())
+
+    subparsers = parser.add_subparsers()
+
+    register_parser = subparsers.add_parser('register')
+    register_parser.add_argument('file', nargs='+', type=Path)
+    register_parser.add_argument('--commit-each', action='store_true')
+    register_parser.set_defaults(action=lambda: register_files(db, args.file, args.commit_each))
+
+    schema_parser = subparsers.add_parser('create-table')
+    schema_parser.set_defaults(action=lambda: create_table(engine))
+
+    args = parser.parse_args()
+
+    logger.addHandler(logging.StreamHandler())
+    logger.setLevel(logging.INFO)
+
+    engine = create_engine(args.db_url, echo=args.echo)
+    SessionClass = sessionmaker(engine)
+    db = SessionClass()
+
+    args.action()
+
+
+def register_files(db: Session, files: List[Path], commit_each: bool):
+    for file in files:
+        logger.info(f'registering {file}...')
+        add_fits_headers_from_file(db, file)
+        if commit_each:
+            try:
+                db.commit()
+            except sqlalchemy.exc.IntegrityError:
+                db.rollback()
+        db.commit()
+
+
+def create_table(engine: Engine):
+    tables = [models.obslog_fits_header]
+    for table in tables:
+        models.Base.metadata.create_all(engine, tables=[table.__table__])
+
+
+if __name__ == '__main__':
+    main()

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ def main():
           description='PFS operational database (opDB) tools',
           author='Kiyoto Yabe',
           url='https://github.com/Subaru-PFS/spt_operational_database',
-          install_requires=['sqlalchemy'],
+          install_requires=['sqlalchemy', 'psycopg2-binary'],
           zip_safe=False,
           include_package_data=True,
           license='',
@@ -23,6 +23,9 @@ def main():
           packages=['opdb'],
           extras_require={
               'dev': [
+                  'numpy',
+                  'pandas',
+                  'astropy',
                   'pytest',
                   'alembic',
                   'pylint',

--- a/tests/test_obslog.py
+++ b/tests/test_obslog.py
@@ -1,0 +1,115 @@
+import datetime
+from pathlib import Path
+from typing import Any, Callable, List, Tuple
+
+import astropy.io.fits as pyfits
+import numpy
+import pytest
+from opdb import models
+from opdb.obslog import fits_headers_from_file, guess_pfs_visit_id
+from sqlalchemy import create_engine, false 
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm.session import Session
+
+pytestmark = pytest.mark.focus
+
+HERE = Path(__file__).parent
+db_url_file = HERE / 'secrets' / 'testdb.url'
+
+FitsFromCardsType = Callable[[List[List[Tuple[str, Any, str]]], str], Path]
+
+
+@pytest.mark.skipif(not db_url_file.exists(), reason='db credentails not provided')
+def test_add_fits_headers_from_file(db: Session, pfs_visit_id: int, fits_from_cards: FitsFromCardsType):
+    sample_fits = fits_from_cards([[
+        ('I_VALUE', 42, 'answer'),
+        ('F_VALUE', 3.14, 'pi'),
+        ('B_VALUE', True, 'true'),
+        ('S_VALUE', 'string', 'string'),
+    ]], 'PFSA01967811.fits')
+    db.add_all(fits_headers_from_file(sample_fits, pfs_visit_id))
+
+    record = db.query(models.obslog_fits_header).filter(
+        models.obslog_fits_header.pfs_visit_id == pfs_visit_id,
+    ).one()
+
+    assert record.filestem == 'PFSA01967811'
+    assert isinstance(record.cards_dict, dict)
+    assert isinstance(record.cards_list, list)
+    assert record.cards_dict['I_VALUE'] == 42
+    assert record.cards_dict['F_VALUE'] == pytest.approx(3.14)
+    assert record.cards_dict['B_VALUE'] is True
+    assert record.cards_dict['S_VALUE'] == 'string'
+
+
+@pytest.mark.parametrize('hdu_index', range(3))
+@pytest.mark.parametrize('name_value_check', [
+    ('I_VALUE', 42, lambda c: c.as_integer() == 42),
+    ('F_VALUE', 3.14, lambda c: c.as_float().between(3.13, 3.14)),
+    ('S_VALUE', 'hello world', lambda c: c.astext.like(r'hello%')),
+    ('B_VALUE', True, lambda c: c.as_boolean()),
+    ('B_VALUE', False, lambda c: c.as_boolean() == false()),
+])
+@pytest.mark.skipif(not db_url_file.exists(), reason='db credentails not provided')
+def test_query(
+    hdu_index: int,
+    name_value_check: Tuple[str, Any, Any],
+    db: Session, fits_from_cards: FitsFromCardsType, pfs_visit_id: int,
+):
+    name, value, check = name_value_check
+    cards_list = [[] for _ in range(3)]
+    cards_list[hdu_index] = [(name, value)]
+
+    sample_fits = fits_from_cards(
+        cards_list,
+        'PFSA01967811.fits',
+    )
+    db.add_all(fits_headers_from_file(sample_fits, pfs_visit_id))
+
+    record = db.query(models.obslog_fits_header).filter(
+        check(models.obslog_fits_header.cards_dict[name]),
+    ).one()
+
+    assert record.filestem == 'PFSA01967811'
+    assert record.hdu_index == hdu_index
+    assert isinstance(record.cards_dict, dict)
+    assert record.cards_dict[name] == value
+
+
+def test_guess_pfs_visit_id():
+    assert guess_pfs_visit_id(Path('/data/raw/2021-09-12/sps/PFSA06645311.fits')) == 66453
+    assert guess_pfs_visit_id(Path('/data/raw/2021-07-18/mcs/PFSC06484800.fits')) == 64848
+    with pytest.raises(RuntimeError):
+        guess_pfs_visit_id(Path('/error/PFSA123456890000.fits'))
+
+
+@pytest.fixture
+def db():
+    engine = create_engine(db_url_file.read_text().strip(), echo=False)
+    SessionClass = sessionmaker(engine)
+    db = SessionClass()
+    try:
+        db.query(models.obslog_fits_header).filter(models.obslog_fits_header.pfs_visit_id < 0).delete()
+        db.query(models.pfs_visit).filter(models.pfs_visit.pfs_visit_id < 0).delete()
+        db.flush()
+        yield db
+    finally:
+        db.rollback()
+
+
+@pytest.fixture
+def pfs_visit_id(db: Session):
+    db.add(models.pfs_visit(pfs_visit_id=-1, pfs_visit_description='', pfs_design_id=-1, issued_at=datetime.datetime.now()))
+    db.flush()
+
+
+@pytest.fixture
+def fits_from_cards(tmp_path: Path):
+    def f(cards_list: List[List[Tuple[str, Any, str]]], filename: str = 'PFSA01967811.fits'):
+        fitsfile_path = tmp_path / filename
+        pyfits.HDUList([
+            pyfits.PrimaryHDU(header=pyfits.Header(cards_list[0])),
+            *(pyfits.ImageHDU(numpy.zeros((1, 1)), header=pyfits.Header(cards)) for cards in cards_list[1:]),
+        ]).writeto(fitsfile_path)
+        return fitsfile_path
+    yield f


### PR DESCRIPTION
## FITS Header Search

This PR is for adding the functionality to store and search FITS headers to opdb.

https://pfspipe.ipmu.jp/jira/browse/INSTRM-1367

FITS headers will be stored in columns with type [JSONB](https://www.postgresql.org/docs/current/datatype-json.html) in obslog_fits_header table.

## Usage

### Store

We can store FITS headers of an existing FITS file as follows:
```python
import opdb.obslog
from opdb.models import pfs_visit

db = SessionClass()

filepath = '/data/raw/2021-09-12/sps/PFSA06645311.fits'
pfs_visit_id = 66453

db.add_all(opdb.obslog.fits_headers_from_file(filepath, pfs_visit))
db.commit()
```

or from HDUList:
```python
import opdb.obslog
import astropy.io.fits as pyfits
from opdb.models import pfs_visit

db = SessionClass()

pfs_visit_id = 66453
filestem = 'PFSA06645311'

hdul = pyfits.HDUList([
  pyfits.PrimaryHDU(header=pyfits.Header([
    ('PI', 3.14, "ratio of a circle's circumference to its diameter"),
  ])),
])

db.add_all(opdb.obslog.fits_headers_from_hdulist(hdul, pfs_visit_id, filestem):
db.commit()
```

or from CLI:

```bash
python -m opdb.obslog -d postgresql://postgres@localhost:5432/opdb /data/raw/2021-09-12/sps/PFS*.fits

# for all the FITS files in a directory
find /data/raw/2020-* -name 'PFS*.fits' | \
xargs -r python -m opdb.obslog -d postgresql://postgres@localhost:5432/opdb --no-echo register --commit-each
```

### Query

```python
pfs_visit_whose_OBSERVAT_is_NAOJ = db.query(models.obslog_fits_header).filter(
    models.obslog_fits_header.cards_dict['OBSERVAT'].astexst == 'NAOJ',
).first().pfs_visit
```
