### PR TITLE
fix: "Undefined variable" errors

### DIFF
--- a/python/opdb/models.py
+++ b/python/opdb/models.py
@@ -2175,15 +2175,15 @@ class agc_guide_offset(Base):
         self.guide_delta_ra = guide_delta_ra
         self.guide_delta_dec = guide_delta_dec
         self.guide_delta_insrot = guide_delta_insrot
-        self.guide_az = guide_az
-        self.guide_el = guide_el
-        self.guide_z = guide_z
-        self.guide_z1 = guide_z1
-        self.guide_z2 = guide_z2
-        self.guide_z3 = guide_z3
-        self.guide_z4 = guide_z4
-        self.guide_z5 = guide_z5
-        self.guide_z6 = guide_z6
+        self.guide_delta_az = guide_delta_az
+        self.guide_delta_el = guide_delta_el
+        self.guide_delta_z = guide_delta_z
+        self.guide_delta_z1 = guide_delta_z1
+        self.guide_delta_z2 = guide_delta_z2
+        self.guide_delta_z3 = guide_delta_z3
+        self.guide_delta_z4 = guide_delta_z4
+        self.guide_delta_z5 = guide_delta_z5
+        self.guide_delta_z6 = guide_delta_z6
 
 
 def make_database(dbinfo):


### PR DESCRIPTION
This PR is for fixing some typos in `opdb.models`.

`opdb.py` also has some errors detected by `pylint`, but I don't know how to fix them.

```bash
$ ./.venv/bin/pylint --errors-only opdb
************* Module opdb.opdb
python/opdb/opdb.py:37:27: E1101: Module 'opdb.models' has no 'tel_condition' member (no-member)
python/opdb/opdb.py:39:27: E1101: Module 'opdb.models' has no 'tel_visit' member (no-member)
python/opdb/opdb.py:1135:29: E1101: Module 'opdb.models' has no 'tel_visit' member (no-member)
python/opdb/opdb.py:1164:43: E1101: Module 'opdb.models' has no 'tel_visit' member (no-member)
python/opdb/opdb.py:1164:68: E1101: Module 'opdb.models' has no 'tel_visit' member (no-member)
python/opdb/opdb.py:1787:4: E0102: method already defined line 865 (function-redefined)
```

I think `tel_condition` is renamed to `tel_status`? but I'm not sure.