### PR TITLE
Add time column to agc_guide_offsets - tickets/INSTRM-2801

### DIFF
--- a/alembic/opdb_summit/alembic/versions/8d61df7ba4ca_new_column_for_recording_ag_time_.py
+++ b/alembic/opdb_summit/alembic/versions/8d61df7ba4ca_new_column_for_recording_ag_time_.py
@@ -1,0 +1,24 @@
+"""New column for recording AG time; tickets/INSTRM-2801
+
+Revision ID: 8d61df7ba4ca
+Revises: 26a4e346fbf1
+Create Date: 2026-04-28 13:59:54.106135
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision = '8d61df7ba4ca'
+down_revision = '26a4e346fbf1'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('agc_guide_offset', sa.Column('taken_at', postgresql.TIMESTAMP(), autoincrement=False, nullable=True))
+
+
+def downgrade():
+    op.drop_column('agc_guide_offset', 'taken_at')

--- a/python/opdb/models.py
+++ b/python/opdb/models.py
@@ -1853,6 +1853,7 @@ class agc_guide_offset(Base):
                             comment='The calculated focus offset for AGC6 [mm]')
     mask = Column(Integer,
                   comment='A mask of the active elements being fit')
+    taken_at = Column(DateTime, comment='The time at which the exposure was taken [YYYY-MM-DDThh-mm-sss]')
 
     agc_exposure = relationship('agc_exposure', back_populates='agc_guide_offset')
 
@@ -1860,7 +1861,7 @@ class agc_guide_offset(Base):
                  guide_delta_ra, guide_delta_dec, guide_delta_insrot, guide_delta_scale,
                  guide_delta_az, guide_delta_el, guide_delta_z,
                  guide_delta_z1, guide_delta_z2, guide_delta_z3, guide_delta_z4, guide_delta_z5, guide_delta_z6,
-                 mask):
+                 mask, taken_at):
         self.agc_exposure_id = agc_exposure_id
         self.guide_ra = guide_ra
         self.guide_dec = guide_dec
@@ -1879,6 +1880,7 @@ class agc_guide_offset(Base):
         self.guide_delta_z5 = guide_delta_z5
         self.guide_delta_z6 = guide_delta_z6
         self.mask = mask
+        self.taken_at = taken_at
 
 
 def make_database(dbinfo):


### PR DESCRIPTION
This time value comes from `mlp1` and has been used in the calculations previously but is not being stored anywhere.  Storing as a plain `TIMESTAMP` (no timezone) because that's how it's being done in other tables (unfortunately).